### PR TITLE
Fix transient-for for popup menu and config dialog.

### DIFF
--- a/config_dialog.c
+++ b/config_dialog.c
@@ -73,6 +73,7 @@ on_button_config (GtkMenuItem *menuitem, gpointer user_data)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     waveform_properties = gtk_dialog_new ();
+    gtk_window_set_transient_for (GTK_WINDOW (waveform_properties), gtk_widget_get_toplevel(menuitem));
     gtk_window_set_title (GTK_WINDOW (waveform_properties), "Waveform Properties");
     gtk_window_set_type_hint (GTK_WINDOW (waveform_properties), GDK_WINDOW_TYPE_HINT_DIALOG);
 

--- a/waveform.c
+++ b/waveform.c
@@ -1249,6 +1249,7 @@ waveform_create (void)
 #endif
     w->frame = gtk_frame_new (NULL);
     w->popup = gtk_menu_new ();
+    gtk_menu_attach_to_widget (GTK_MENU (w->popup), w->base.widget, NULL);
     w->popup_item = gtk_menu_item_new_with_mnemonic ("Configure");
     w->mutex = deadbeef->mutex_create ();
     gtk_widget_set_size_request (w->base.widget, 300, 96);


### PR DESCRIPTION
Gtk3 needs this for correct positioning on Wayland.

This code should have been used all along even on GTK2 but it coped well without it.
