### PR TITLE
redraw only parts of the waveform to reduce cpu load a lot

### DIFF
--- a/waveform.c
+++ b/waveform.c
@@ -308,7 +308,24 @@ static gboolean
 waveform_draw_cb (void *user_data)
 {
     waveform_t *w = user_data;
-    gtk_widget_queue_draw (w->drawarea);
+
+    DB_playItem_t *trk = deadbeef->streamer_get_playing_track ();
+    if (!trk) {
+        return;
+    }
+    
+    GtkAllocation a;
+    gtk_widget_get_allocation (w->drawarea, &a);
+    const int width = a.width;
+    const int height = a.height;
+    const float dur = deadbeef->pl_get_item_duration (trk);
+    const float pos = (deadbeef->streamer_get_playpos () * width)/ dur;
+    // use 8 times (*8/1000 => /125 ) the amount of pixels per refresh to 
+    // prevent skipped areas
+    float size = width/dur * CONFIG_REFRESH_INTERVAL/125;
+    // redraw only from pos-size to pos+size
+    gtk_widget_queue_draw_area (w->drawarea, ceil (pos-size), 0, ceil (2*size), height);
+
     return TRUE;
 }
 

--- a/waveform.c
+++ b/waveform.c
@@ -323,6 +323,10 @@ waveform_draw_cb (void *user_data)
     // use 8 times (*8/1000 => /125 ) the amount of pixels per refresh to 
     // prevent skipped areas
     float size = width/dur * CONFIG_REFRESH_INTERVAL/125;
+
+    const double doubleCursorWidth = CONFIG_CURSOR_WIDTH * 2;
+    size = (size < doubleCursorWidth ? doubleCursorWidth : size);
+
     // redraw only from pos-size to pos+size
     gtk_widget_queue_draw_area (w->drawarea, ceil (pos-size), 0, ceil (2*size), height);
 


### PR DESCRIPTION
After the waveform is already calculated, really only a small part of it needs to be redrawn as most of it stays the same. Only the part around the current position changes.

This also greatly reduces the cpu load. For me it went from 65-70% CPU usage on one core down to 1-2% CPU usage on one core.