### PR TITLE
fix build with clang

### DIFF
--- a/waveform.c
+++ b/waveform.c
@@ -323,7 +323,7 @@ waveform_draw_cb (void *user_data)
 
     DB_playItem_t *trk = deadbeef->streamer_get_playing_track ();
     if (!trk) {
-        return;
+        return FALSE;
     }
     
     GtkAllocation a;


### PR DESCRIPTION
```
% make CC=clang
Creating build directory for GTK+2 version
Compiling support.o
Compiling draw_utils.o
Compiling config.o
Compiling waveform.o
waveform.c:326:9: error: non-void function 'waveform_draw_cb' should return a value [-Wreturn-type]
        return;
        ^
1 error generated.
make: *** [Makefile:96: gtk2/waveform.o] Error 1
```

clang does not allow `return;` without a value in a function that's supposed to return one

(is `FALSE` the right return value here? i think that's what it was previously doing with gcc)