### PR TITLE
Redraw on seek

### DIFF
--- a/waveform.c
+++ b/waveform.c
@@ -1168,6 +1168,9 @@ waveform_message (ddb_gtkui_widget_t *widget, uint32_t id, uintptr_t ctx, uint32
             playback_status = PLAYING;
             waveform_set_refresh_interval (w, CONFIG_REFRESH_INTERVAL);
         }
+        break;
+    case DB_EV_SEEKED:
+        g_idle_add (waveform_redraw_cb, w);
     }
     return 0;
 }


### PR DESCRIPTION
Waveform isn't correctly rendered if something other than clicking in the waveform seekbar causes a seek so always redraw on seek.